### PR TITLE
Add flag to defer errors from PlutusTx plugin

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -38,6 +38,8 @@ index-state:
 
 tests: true
 
+haddock-options: "--optghc=-fplugin-opt PlutusTx.Plugin:defer-errors"
+
 -- Always show detailed output for tests
 test-show-details: direct
 

--- a/hydra-auction.cabal
+++ b/hydra-auction.cabal
@@ -79,6 +79,13 @@ common common-lang
 
   default-language:   Haskell2010
 
+flag defer-plugin-errors
+  description:
+    Defer errors from the PlutusTx plugin, which break HLS and Haddock.
+
+  default:     False
+  manual:      True
+
 executable hydra-auction
   import:         common-lang
   main-is:        Main.hs
@@ -167,6 +174,9 @@ library
     , time
 
   hs-source-dirs:  src
+
+  if flag(defer-plugin-errors)
+    ghc-options: -fplugin-opt PlutusTx.Plugin:defer-errors
 
 test-suite hydra-auction-test
   import:         common-lang


### PR DESCRIPTION
Note that this **doesn't** turn on `fplugin-opt PlutusTx.Plugin:defer-errors` by default.

It only turns it on for Haddock (which breaks otherwise) and if manually triggered via the `defer-plugin-errors` package flag.